### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository show's how to use [SageMaker's real-time inference endpoints](ht
 
 ## Getting Started
 
-In order to run the example in this repo, navigate to the [notebook](./whisper-inference-deploy.ipynb). This notebook can be run end-to-end in [Sagemaker Studio](https://aws.amazon.com/sagemaker/studio/). We recommend using the Python 3 (Data Science 2.0) with Python 3.8, and a ml.m5.large instance inside of SageMaker Studio to run the notebook. Running through the notebook you will be able to...
+In order to run the example in this repo, navigate to the [notebook](./whisper-inference-deploy.ipynb). This notebook can be run end-to-end in [Sagemaker Studio](https://aws.amazon.com/sagemaker/studio/). We recommend using the Python 3 (Data Science 3.0) with Python 3.10, and a ml.m5.large instance inside of SageMaker Studio to run the notebook. Running through the notebook you will be able to...
 
 1. Save a serialized Whisper model to Amazon S3
 2. Create a SageMaker model object from this serialized model

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository show's how to use [SageMaker's real-time inference endpoints](ht
 
 ## Getting Started
 
-In order to run the example in this repo, navigate to the [notebook](./whisper-inference-deploy.ipynb). This notebook can be run end-to-end in [Sagemaker Studio](https://aws.amazon.com/sagemaker/studio/). We recommend using the Data Science image, the Python 3 kernel, and a ml.m5.large instance inside of SageMaker Studio to run the notebook. Running through the notebook you will be able to...
+In order to run the example in this repo, navigate to the [notebook](./whisper-inference-deploy.ipynb). This notebook can be run end-to-end in [Sagemaker Studio](https://aws.amazon.com/sagemaker/studio/). We recommend using the Python 3 (Data Science 2.0) with Python 3.8, and a ml.m5.large instance inside of SageMaker Studio to run the notebook. Running through the notebook you will be able to...
 
 1. Save a serialized Whisper model to Amazon S3
 2. Create a SageMaker model object from this serialized model


### PR DESCRIPTION
Python 3.7 doesn't support ```:=```

*Issue #, if available:*

*Description of changes:*
- Using the default Data Science kernel will throw an error because 3.7 does not support the walrus operator in the whisper package. 


<img width="628" alt="Screenshot 2023-04-04 at 11 35 16 AM" src="https://user-images.githubusercontent.com/11032490/229892760-37b96081-90e0-4882-b44f-12017182a2a6.png">

<img width="747" alt="Screenshot 2023-04-04 at 11 53 34 AM" src="https://user-images.githubusercontent.com/11032490/229892755-18951d86-5982-4fab-8743-4d4868ba2860.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
